### PR TITLE
Add competitions managing

### DIFF
--- a/src/Controller/Cms/CompetitionController.php
+++ b/src/Controller/Cms/CompetitionController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BalticRobo\Api\Controller\Cms;
+
+use BalticRobo\Api\Entity\Competition\Competition;
+use BalticRobo\Api\Model\Cms\AddCompetitionDTO;
+use BalticRobo\Api\Service\Cms\CompetitionService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class CompetitionController extends Controller
+{
+    private $competitionService;
+
+    public function __construct(CompetitionService $competitionService)
+    {
+        $this->competitionService = $competitionService;
+    }
+
+    /**
+     * @Route("/cms/{year}/competition/list", name="cms_competition_list", requirements={"year" = "\d+"}, methods={"GET"})
+     * *
+     * @param int     $year
+     */
+    public function listAction(int $year): Response
+    {
+        $records = $this->competitionService->getListByYear($year);
+
+        $records = $records->map(function(Competition $competition){
+            return ['id' => $competition->getId(),
+                    'name' => $competition->getName(),
+                    'display_name' => $competition->getDisplayName(),
+                    'registration_type' => $competition->getRegistrationType()];
+        });
+
+        return $this->json(['data' => ['competitions' => $records->toArray()], 'year' => $year, 'count' => $records->count()], Response::HTTP_OK);
+    }
+
+    /**
+     * @Route("/cms/{year}/competition/add", name="cms_competition_add", requirements={"year" = "\d+"}, methods={"POST"})
+     * *
+     * @param int     $year
+     */
+    public function addAction(Request $request, int $year): Response
+    {
+        $this->competitionService->add(AddCompetitionDTO::createFromRequestAndYear($request, $year));
+
+        return $this->json(['data' => ['success' => true]], Response::HTTP_OK);
+    }
+}

--- a/src/Entity/Competition/Competition.php
+++ b/src/Entity/Competition/Competition.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace BalticRobo\Api\Entity\Competition;
+
+use BalticRobo\Api\Model\Cms\AddCompetitionDTO;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="BalticRobo\Api\Repository\Competition\CompetitionRepository")
+ */
+class Competition
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     */
+    private $display_name;
+
+    /**
+     * @ORM\Column(type="string", length=64)
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="smallint")
+     */
+    private $year;
+
+    /**
+     * @ORM\Column(type="smallint")
+     */
+    private $registrationType;
+
+    public static function createFromAddDTO(AddCompetitionDTO $dto): self
+    {
+        $entity = new self();
+        $entity->display_name = $dto->getDisplayName();
+        $entity->name = $dto->getName();
+        $entity->year = $dto->getYear();
+        $entity->registrationType = $dto->getRegistrationType();
+
+        return $entity;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDisplayName(): ?string
+    {
+        return $this->display_name;
+    }
+
+    public function setDisplayName(string $display_name): self
+    {
+        $this->display_name = $display_name;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getYear(): ?int
+    {
+        return $this->year;
+    }
+
+    public function setYear(int $year): self
+    {
+        $this->year = $year;
+
+        return $this;
+    }
+
+    public function getRegistrationType(): ?int
+    {
+        return $this->registrationType;
+    }
+
+    public function setRegistrationType(int $registrationType): self
+    {
+        $this->registrationType = $registrationType;
+
+        return $this;
+    }
+}

--- a/src/Migrations/Version20181208160025.php
+++ b/src/Migrations/Version20181208160025.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace BalticRobo\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181208160025 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE competition (id INT AUTO_INCREMENT NOT NULL, display_name VARCHAR(64) NOT NULL, name VARCHAR(64) NOT NULL, year SMALLINT NOT NULL, registration_type SMALLINT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE users CHANGE roles roles JSON NOT NULL COMMENT \'(DC2Type:json_collection)\', CHANGE created_at created_at INT NOT NULL COMMENT \'(DC2Type:timestamp_immutable)\', CHANGE last_login_at last_login_at INT DEFAULT NULL COMMENT \'(DC2Type:timestamp_immutable)\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE competition');
+        $this->addSql('ALTER TABLE users CHANGE created_at created_at INT NOT NULL, CHANGE last_login_at last_login_at INT DEFAULT NULL, CHANGE roles roles JSON NOT NULL');
+    }
+}

--- a/src/Model/Cms/AddCompetitionDTO.php
+++ b/src/Model/Cms/AddCompetitionDTO.php
@@ -1,0 +1,69 @@
+<?php
+namespace BalticRobo\Api\Model\Cms;
+
+
+use Symfony\Component\HttpFoundation\Request;
+
+class AddCompetitionDTO
+{
+    private $display_name;
+    private $name;
+    private $year;
+    private $registartionType;
+
+    private function __construct()
+    {
+    }
+
+    public static function createFromRequestAndYear(Request $request, int $year): self{
+        $content = json_decode($request->getContent(), true);
+        $dto = new self();
+
+        $dto->setDisplayName($content['display_name']);
+        $dto->setName($content['name']);
+        $dto->setYear($year);
+        $dto->setRegistrationType($content['registration_type']);
+
+        return $dto;
+    }
+
+    public function getDisplayName(): ?string
+    {
+        return $this->display_name;
+    }
+
+    public function setDisplayName(string $display_name): void
+    {
+        $this->display_name = $display_name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getYear(): ?int
+    {
+        return $this->year;
+    }
+
+    public function setYear(int $year): void
+    {
+        $this->year = $year;
+    }
+
+    public function getRegistrationType(): ?int
+    {
+        return $this->registartionType;
+    }
+
+    public function setRegistrationType(int $registartionType): void
+    {
+        $this->registartionType = $registartionType;
+    }
+}

--- a/src/Repository/Competition/CompetitionRepository.php
+++ b/src/Repository/Competition/CompetitionRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BalticRobo\Api\Repository\Competition;
+
+use BalticRobo\Api\Entity\Competition\Competition;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @method Competition|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Competition|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Competition[]    findAll()
+ * @method Competition[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class CompetitionRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Competition::class);
+    }
+
+    public function getTotal(): int
+    {
+        return $this->count([]);
+    }
+
+    public function getRecordsByYear(int $year): Collection
+    {
+        return new ArrayCollection($this->findBy(['year' => $year]));
+    }
+
+    public function save(Competition $competition): void
+    {
+        $this->getEntityManager()->persist($competition);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/src/Service/Cms/CompetitionService.php
+++ b/src/Service/Cms/CompetitionService.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace BalticRobo\Api\Service\Cms;
+
+use BalticRobo\Api\Entity\Competition\Competition;
+use BalticRobo\Api\Model\Cms\AddCompetitionDTO;
+use BalticRobo\Api\Repository\Competition\CompetitionRepository;
+use Doctrine\Common\Collections\Collection;
+
+class CompetitionService
+{
+    private $competitionRepository;
+
+    public function __construct(CompetitionRepository $competitionRepository)
+    {
+        $this->competitionRepository = $competitionRepository;
+    }
+
+    public function getListByYear(int $year): Collection
+    {
+        return $this->competitionRepository->getRecordsByYear($year);
+    }
+
+    public function getTotal(): int
+    {
+        return $this->competitionRepository->getTotal();
+    }
+
+    public function add(AddCompetitionDTO $competitionDTO): void
+    {
+        $this->competitionRepository->save(Competition::createFromAddDTO($competitionDTO));
+    }
+}


### PR DESCRIPTION
First steps in implementations of CMS. Allow to add new competitions and list them.
The objects (event,competitions,rules,etc.) will be divided by years (2018,2019...)